### PR TITLE
Change to pipeline operator syntax for fmt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     prompts (0.2.1)
-      fmt
+      fmt (>= 0.3.0)
       rainbow
       reline
       unicode-display_width
@@ -12,7 +12,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    fmt (0.1.3)
+    fmt (0.3.1)
+      ast
     io-console (0.7.2)
     json (2.7.2)
     language_server-protocol (3.17.0.3)

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -2,10 +2,8 @@
 
 require "io/console"
 require "reline"
+require "rainbow" # this needs to come before require "fmt"
 require "fmt"
-require "rainbow"
-
-Fmt.add_rainbow_filters
 
 require_relative "prompts/version"
 require_relative "prompts/prompt"

--- a/lib/prompts/box.rb
+++ b/lib/prompts/box.rb
@@ -55,16 +55,16 @@ module Prompts
 
     def top_border
       border = @border_parts[:top_left] + @border_parts[:horizontal] * (@width - 2) + @border_parts[:top_right]
-      Fmt("#{@line_padding}%{border}#{@border_color}", border: border)
+      Fmt("#{@line_padding}%{border}|>#{@border_color}", border: border)
     end
 
     def bottom_border
       border = @border_parts[:bottom_left] + @border_parts[:horizontal] * (@width - 2) + @border_parts[:bottom_right]
-      Fmt("#{@line_padding}%{border}#{@border_color}", border: border)
+      Fmt("#{@line_padding}%{border}|>#{@border_color}", border: border)
     end
 
     def align(text, alignment, between: @border_parts[:vertical])
-      formatted_boundary = Fmt("%{boundary}#{@border_color}", boundary: between)
+      formatted_boundary = Fmt("%{boundary}|>#{@border_color}", boundary: between)
       wrap_text(text, width: @width, line_prefix: formatted_boundary + SPACE, line_suffix: SPACE + formatted_boundary, alignment: alignment)
     end
   end

--- a/lib/prompts/prompt.rb
+++ b/lib/prompts/prompt.rb
@@ -61,7 +61,7 @@ module Prompts
 
         if (@error = ensure_validity(response))
           @content.reset!
-          @content.paragraph Fmt("%{error}red|bold", error: @error + " Try again (×#{@attempts})...")
+          @content.paragraph Fmt("%{error}|>red|>bold", error: @error + " Try again (×#{@attempts})...")
           @attempts += 1
           next
         else
@@ -114,20 +114,20 @@ module Prompts
 
     def formatted_prompt
       prompt_with_space = @prompt.end_with?(SPACE) ? @prompt : @prompt + SPACE
-      ansi_prompt = Fmt("%{prompt}faint|bold", prompt: prompt_with_space)
+      ansi_prompt = Fmt("%{prompt}|>faint|>bold", prompt: prompt_with_space)
       @formatted_prompt ||= Paragraph.new(ansi_prompt, width: MAX_WIDTH).lines
     end
 
     def formatted_label
-      Fmt("%{label}cyan|bold %{instructions}faint|italic", label: @label, instructions: @instructions ? "(#{@instructions})" : "")
+      Fmt("%{label}|>cyan|>bold %{instructions}|>faint|>italic", label: @label, instructions: @instructions ? "(#{@instructions})" : "")
     end
 
     def formatted_hint
-      Fmt("%{hint}faint|bold", hint: @hint)
+      Fmt("%{hint}|>faint|>bold", hint: @hint)
     end
 
     def formatted_error
-      Fmt("%{error}red|bold", error: @error + " Try again (×#{@attempts})...")
+      Fmt("%{error}|>red|>bold", error: @error + " Try again (×#{@attempts})...")
     end
 
     def ensure_validity(response)

--- a/lib/prompts/select_prompt.rb
+++ b/lib/prompts/select_prompt.rb
@@ -29,7 +29,7 @@ module Prompts
     def prepare_content
       super
       @options.each_with_index do |(key, value), index|
-        @content.paragraph Fmt("%{prefix}faint|bold %{option}", prefix: "#{index + 1}.", option: value)
+        @content.paragraph Fmt("%{prefix}|>faint|>bold %{option}", prefix: "#{index + 1}.", option: value)
       end
       @content
     end

--- a/prompts.gemspec
+++ b/prompts.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "unicode-display_width"
   spec.add_dependency "unicode-emoji"
   spec.add_dependency "reline"
-  spec.add_dependency "fmt"
+  spec.add_dependency "fmt", ">= 0.3.0"
   spec.add_dependency "rainbow"
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
I hit the following issue trying to use `prompts` in a new project.

I solved it by going into the `Fmt` readme: https://github.com/hopsoft/fmt?tab=readme-ov-file#rainbow-gem

and noticed it changed to using pipeline operators, removed the `Fmt.add_rainbow_colors` and so I used `bundle open`, made the following changes, and it worked for me.

Fixes #8 