### PR TITLE
Keep past frames in the terminal window

### DIFF
--- a/lib/prompts/content.rb
+++ b/lib/prompts/content.rb
@@ -64,7 +64,7 @@ module Prompts
     end
 
     def erase_down
-      OUTPUT.print "\e[J"
+      OUTPUT.print "\e[2J\e[H"
     end
   end
 end


### PR DESCRIPTION
Instead of clearing the screen for each new frame, simply new frame to the top of the terminal viewport. This keeps all past frames present and scrollable into view by scrolling up.

Resolves #5.